### PR TITLE
increase color contrast to fix issue 9

### DIFF
--- a/config.js
+++ b/config.js
@@ -16,6 +16,7 @@ const colors = {
 		tint20: '#5F9C34',
 		tint30: '#55952F',
 		tint40: '#498D29',
+		tint50: '#238636',
 	},
 	red: '#D53232',
 	black: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "greenhouse-react-ui",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"description": "React UI component library built with Tailwind CSS",
 	"main": "dist/index.js",
 	"module": "dist/index.esm.js",

--- a/src/TextArea.tsx
+++ b/src/TextArea.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import {
 	forwardRef,
-	InputHTMLAttributes,
+	TextareaHTMLAttributes,
 	useContext,
 	useRef,
 	useState,
@@ -9,7 +9,7 @@ import {
 import { ThemeContext } from './context/ThemeContext'
 import { mergeRefs } from './utils/warning'
 
-export type TextareaProps = InputHTMLAttributes<HTMLTextAreaElement> & {
+export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
 	invalid?: boolean
 	className?: string
 	disabled?: boolean

--- a/src/themes/default.ts
+++ b/src/themes/default.ts
@@ -9,13 +9,13 @@ export default {
 			small: 'px-3 py-1 rounded text-sm',
 		},
 		layout: {
-			primary: 'border border-primary bg-primary text-white',
+			primary: 'border border-primary bg-primary-tint50 text-white',
 			outline: 'border border-primary text-primary',
 			link: 'underline text-primary !px-0 !py-0',
 		},
 		active: {
 			primary:
-				'active:bg-primary-tint20 focus-visible:ring focus-visible:ring-primary-shade70/70',
+				'active:bg-primary-tint50 focus-visible:ring focus-visible:ring-primary-shade70/70',
 			outline:
 				'active:bg-transparent active:text-primary focus-visible:ring focus-visible:ring-primary-shade70/30',
 			link: 'active:bg-transparent active:text-primary focus-visible:ring focus-visible:ring-primary-shade70/70',


### PR DESCRIPTION
As reported in issue #9 , the primary buttons do not mean the minimum color contrast radio theshold. 

This is fixed by chosen a slightly darker shade of the primary color.