### PR TITLE
Issue 11: Create Badge Component

### DIFF
--- a/src/Badge.tsx
+++ b/src/Badge.tsx
@@ -1,0 +1,45 @@
+import React, { HTMLAttributes, forwardRef } from 'react'
+import clsx from 'clsx'
+import { warn } from './utils/warning'
+import { ThemeContext } from './context/ThemeContext'
+
+type BadgeProps = HTMLAttributes<HTMLSpanElement> & { 
+    children: React.ReactNode,
+    className?: string
+    color?: 'neutral' | 'success' | 'danger' | 'warning'
+}
+
+const Badge = forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
+    const theme = React.useContext(ThemeContext)
+    const { badge: badgeTheme } = theme
+
+    const baseStyle = badgeTheme.base
+    const layoutStyles = {
+		neutral: badgeTheme.neutral,
+		success: badgeTheme.success,
+        danger: badgeTheme.danger,
+        warning: badgeTheme.warning
+	}
+
+    const {
+        children,
+        className,
+        color = 'neutral',
+        ...other
+    } = props
+
+    warn(!children, 'Badge', 'you must pass a children to the Badge component')
+    
+    const cls = clsx(
+		baseStyle,
+        layoutStyles[color]
+	)
+    
+    return (
+        <span ref={ref} className={cls} {...other}>
+            {children}
+        </span>
+    )
+})
+
+export default Badge

--- a/src/Badge.tsx
+++ b/src/Badge.tsx
@@ -3,44 +3,35 @@ import clsx from 'clsx'
 import { warn } from './utils/warning'
 import { ThemeContext } from './context/ThemeContext'
 
-export type BadgeProps = HTMLAttributes<HTMLSpanElement> & { 
-    children: React.ReactNode,
-    className?: string
-    color?: 'neutral' | 'success' | 'danger' | 'warning'
+export type BadgeProps = HTMLAttributes<HTMLSpanElement> & {
+	children: React.ReactNode
+	className?: string
+	color?: 'neutral' | 'success' | 'danger' | 'warning'
 }
 
 const Badge = forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
-    const theme = React.useContext(ThemeContext)
-    const { badge: badgeTheme } = theme
+	const theme = React.useContext(ThemeContext)
+	const { badge: badgeTheme } = theme
 
-    const baseStyle = badgeTheme.base
-    const layoutStyles = {
+	const baseStyle = badgeTheme.base
+	const layoutStyles = {
 		neutral: badgeTheme.neutral,
 		success: badgeTheme.success,
-        danger: badgeTheme.danger,
-        warning: badgeTheme.warning
+		danger: badgeTheme.danger,
+		warning: badgeTheme.warning,
 	}
 
-    const {
-        children,
-        className,
-        color = 'neutral',
-        ...other
-    } = props
+	const { children, className, color = 'neutral', ...other } = props
 
-    warn(!children, 'Badge', 'you must pass a children to the Badge component')
-    
-    const cls = clsx(
-		baseStyle,
-        className,
-        layoutStyles[color]
+	warn(!children, 'Badge', 'you must pass a children to the Badge component')
+
+	const cls = clsx(baseStyle, className, layoutStyles[color])
+
+	return (
+		<span ref={ref} className={cls} {...other}>
+			{children}
+		</span>
 	)
-    
-    return (
-        <span ref={ref} className={cls} {...other}>
-            {children}
-        </span>
-    )
 })
 
 export default Badge

--- a/src/Badge.tsx
+++ b/src/Badge.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import { warn } from './utils/warning'
 import { ThemeContext } from './context/ThemeContext'
 
-type BadgeProps = HTMLAttributes<HTMLSpanElement> & { 
+export type BadgeProps = HTMLAttributes<HTMLSpanElement> & { 
     children: React.ReactNode,
     className?: string
     color?: 'neutral' | 'success' | 'danger' | 'warning'
@@ -32,6 +32,7 @@ const Badge = forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
     
     const cls = clsx(
 		baseStyle,
+        className,
         layoutStyles[color]
 	)
     

--- a/src/stories/Badge.stories.jsx
+++ b/src/stories/Badge.stories.jsx
@@ -2,40 +2,40 @@ import React from 'react'
 import Badge from '../Badge'
 
 export default {
-    title: 'Components/Badge',
-    component: Badge,
-    argTypes: {},
+	title: 'Components/Badge',
+	component: Badge,
+	argTypes: {},
 }
 
 const Template = args => <Badge {...args}>Badge</Badge>
 
 export const Base = Template.bind({})
 Base.args = {
-    className: 'test-class-name',
-    color: 'base',
+	className: 'test-class-name',
+	color: 'base',
 }
 
 export const Neutral = Template.bind({})
 
 Neutral.args = {
-    className: 'test-class-name',
-    color: 'neutral',
+	className: 'test-class-name',
+	color: 'neutral',
 }
 
 export const Success = Template.bind({})
 Success.args = {
-    className: 'test-class-name',
-    color: 'success',
+	className: 'test-class-name',
+	color: 'success',
 }
 
 export const Danger = Template.bind({})
 Danger.args = {
-    className: 'test-class-name',
-    color: 'danger',
+	className: 'test-class-name',
+	color: 'danger',
 }
 
 export const Warning = Template.bind({})
 Warning.args = {
-    className: 'test-class-name',
-    color: 'warning',
+	className: 'test-class-name',
+	color: 'warning',
 }

--- a/src/stories/Badge.stories.jsx
+++ b/src/stories/Badge.stories.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import Badge from '../Badge'
+
+export default {
+    title: 'Components/Badge',
+    component: Badge,
+    argTypes: {},
+}
+
+const Template = args => <Badge {...args}>Badge</Badge>
+
+export const Base = Template.bind({})
+Base.args = {
+    className: 'test-class-name',
+    color: 'base',
+}
+
+export const Neutral = Template.bind({})
+
+Neutral.args = {
+    className: 'test-class-name',
+    color: 'neutral',
+}
+
+export const Success = Template.bind({})
+Success.args = {
+    className: 'test-class-name',
+    color: 'success',
+}
+
+export const Danger = Template.bind({})
+Danger.args = {
+    className: 'test-class-name',
+    color: 'danger',
+}
+
+export const Warning = Template.bind({})
+Warning.args = {
+    className: 'test-class-name',
+    color: 'warning',
+}

--- a/src/tests/Badge.test.tsx
+++ b/src/tests/Badge.test.tsx
@@ -5,34 +5,34 @@ import Badge from '../Badge'
 import theme from '../themes/default'
 
 describe('Badge', () => {
-  it('renders without crashing', () => {
-    const { container } = render(<Badge>Test</Badge>)
-    expect(container.firstChild).toBeInTheDocument()
-  })
+	it('renders without crashing', () => {
+		const { container } = render(<Badge>Test</Badge>)
+		expect(container.firstChild).toBeInTheDocument()
+	})
 
-  it('renders children correctly', () => {
-    render(<Badge>Test</Badge>)
-    expect(screen.getByText('Test')).toBeInTheDocument()
-  })
+	it('renders children correctly', () => {
+		render(<Badge>Test</Badge>)
+		expect(screen.getByText('Test')).toBeInTheDocument()
+	})
 
-  it('applies the correct class for color', () => {
-    const { container } = render(<Badge color='danger'>Test</Badge>)
-    expect(container.firstChild).toHaveClass(theme.badge.danger)
-  })
+	it('applies the correct class for color', () => {
+		const { container } = render(<Badge color="danger">Test</Badge>)
+		expect(container.firstChild).toHaveClass(theme.badge.danger)
+	})
 
-  it('applies the correct class for neutral color when color prop is not provided', () => {
-    const { container } = render(<Badge>Test</Badge>)
-    expect(container.firstChild).toHaveClass(theme.badge.neutral)
-  })
+	it('applies the correct class for neutral color when color prop is not provided', () => {
+		const { container } = render(<Badge>Test</Badge>)
+		expect(container.firstChild).toHaveClass(theme.badge.neutral)
+	})
 
-  it('applies custom classes when provided', () => {
-    const { container } = render(<Badge className='custom-class'>Test</Badge>)
-    expect(container.firstChild).toHaveClass('custom-class')
-  })
+	it('applies custom classes when provided', () => {
+		const { container } = render(<Badge className="custom-class">Test</Badge>)
+		expect(container.firstChild).toHaveClass('custom-class')
+	})
 
-  it('forwards ref to the span element', () => {
-    const ref = React.createRef<HTMLSpanElement>()
-    render(<Badge ref={ref}>Test</Badge>)
-    expect(ref.current).toBeInstanceOf(HTMLSpanElement)
-  })
+	it('forwards ref to the span element', () => {
+		const ref = React.createRef<HTMLSpanElement>()
+		render(<Badge ref={ref}>Test</Badge>)
+		expect(ref.current).toBeInstanceOf(HTMLSpanElement)
+	})
 })

--- a/src/tests/Badge.test.tsx
+++ b/src/tests/Badge.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import Badge from '../Badge'
+import theme from '../themes/default'
+
+describe('Badge', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<Badge>Test</Badge>)
+    expect(container.firstChild).toBeInTheDocument()
+  })
+
+  it('renders children correctly', () => {
+    render(<Badge>Test</Badge>)
+    expect(screen.getByText('Test')).toBeInTheDocument()
+  })
+
+  it('applies the correct class for color', () => {
+    const { container } = render(<Badge color='danger'>Test</Badge>)
+    expect(container.firstChild).toHaveClass(theme.badge.danger)
+  })
+
+  it('applies the correct class for neutral color when color prop is not provided', () => {
+    const { container } = render(<Badge>Test</Badge>)
+    expect(container.firstChild).toHaveClass(theme.badge.neutral)
+  })
+
+  it('applies custom classes when provided', () => {
+    const { container } = render(<Badge className='custom-class'>Test</Badge>)
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+
+  it('forwards ref to the span element', () => {
+    const ref = React.createRef<HTMLSpanElement>()
+    render(<Badge ref={ref}>Test</Badge>)
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement)
+  })
+})

--- a/src/themes/default.ts
+++ b/src/themes/default.ts
@@ -63,7 +63,7 @@ export default {
 		neutral: 'text-gray-700 bg-gray-100 dark:text-gray-100 dark:bg-gray-700',
 		success:
 			'text-primary-tint40 bg-primary-shade60 dark:bg-primary-tint40 dark:text-primary-shade60',
-		danger: 'text-red-200 bg-red dark:text-red dark:bg-red-700',
+		danger: 'text-red-700 bg-red-100 dark:text-red-100 dark:bg-red-700',
 		warning: 'text-orange-700 bg-orange-100 dark:text-white dark:bg-orange-600',
 	},
 }

--- a/src/themes/default.ts
+++ b/src/themes/default.ts
@@ -58,4 +58,11 @@ export default {
 			small: 'w-6 h-6',
 		},
 	},
+	badge: {
+		base: 'inline-flex px-2 text-xs font-medium leading-5 rounded-full',
+		neutral: 'text-gray-700 bg-gray-100 dark:text-gray-100 dark:bg-gray-700',
+		success: 'text-primary-tint40 bg-primary-shade60 dark:bg-primary-tint40 dark:text-primary-shade60',
+		danger: 'text-red-200 bg-red dark:text-red dark:bg-red-700',
+		warning: 'text-orange-700 bg-orange-100 dark:text-white dark:bg-orange-600',
+	},
 }

--- a/src/themes/default.ts
+++ b/src/themes/default.ts
@@ -61,7 +61,8 @@ export default {
 	badge: {
 		base: 'inline-flex px-2 text-xs font-medium leading-5 rounded-full',
 		neutral: 'text-gray-700 bg-gray-100 dark:text-gray-100 dark:bg-gray-700',
-		success: 'text-primary-tint40 bg-primary-shade60 dark:bg-primary-tint40 dark:text-primary-shade60',
+		success:
+			'text-primary-tint40 bg-primary-shade60 dark:bg-primary-tint40 dark:text-primary-shade60',
 		danger: 'text-red-200 bg-red dark:text-red dark:bg-red-700',
 		warning: 'text-orange-700 bg-orange-100 dark:text-white dark:bg-orange-600',
 	},


### PR DESCRIPTION
**PR changes:**

- [X] Add Props: color?: 'neutral' | 'success' | 'danger' | 'warning', defaults to 'neutral'.
- [X] Styles: I have added the colors below just on top of my head, feel free to make adjustments if the final look is not good
 
 ```
 badge: {
    base: 'inline-flex px-2 text-xs font-medium leading-5 rounded-full',
    neutral: 'text-gray-700 bg-gray-100 dark:text-gray-100 dark:bg-gray-700',
    success: 'text-primary-tint40 bg-primary-shade60 dark:bg-primary-tint40 dark:text-primary-shade60',
    danger: 'text-red-700 bg-red-100 dark:text-red-100 dark:bg-red-700',
    warning: 'text-orange-700 bg-orange-100 dark:text-white dark:bg-orange-600',
  },
  ```
- [X] Please use the span tag as the base element for building the badge
- [X] The component should be extensible. So the user should be able className, children and other native HTML props which should be applied to the span tag. Already implemented in other components. Please have a look
- [X] Add unit tests to test the above requirements, please have a look at tests written for other components
[X] Add the component to storybook

**Visual Changes:**

![badge-stories](https://github.com/kirandash/greenhouse-react-ui/assets/32891808/86c6cd5f-cca0-4ea7-8e32-d158780c344e)

**Test passing:**

![tests-passing](https://github.com/kirandash/greenhouse-react-ui/assets/32891808/b568b2ca-70c5-4d8d-b811-77f2758f3177)


**Small issue:**

For the `danger` styles: `text-red-700 bg-red-100 dark:text-red-100 dark:bg-red-700`, I had to use `bg-red` instead 'cause Tailwind styles don't get injected for some strange reason. Also `text-red-700` doesn't work. If you find a workaround, I am happ to push the changes @kirandash 